### PR TITLE
clkcar: Disable all write access

### DIFF
--- a/components/clkcar/src/fwd_driver.c
+++ b/components/clkcar/src/fwd_driver.c
@@ -244,8 +244,8 @@ void gen_fwd_write(size_t addr, uint32_t value)
         return;
     }
 
-    uint32_t valueupdate = value;
-    handle_register(addr, &valueupdate, WRITE_ACCESS);
+//    uint32_t valueupdate = value;
+//    handle_register(addr, &valueupdate, WRITE_ACCESS);
 }
 
 void gen_fwd__init() {


### PR DESCRIPTION
Disable all writing requests from Linux VM to the clock and reset registers